### PR TITLE
[INFRA] deploy: 도커 컨테이너 서버 시간 서울로 설정

### DIFF
--- a/exec/deploy-backend/docker-compose.yml
+++ b/exec/deploy-backend/docker-compose.yml
@@ -14,6 +14,7 @@ services:
     volumes:
       - ${HOME}/d102/mariadb/var/lib/mysql:/var/lib/mysql
     environment:
+      TZ: "Asia/Seoul"
       MARIADB_ROOT_PASSWORD: ${MARIADB_ROOT_PASSWORD}
       MARIADB_USER: ${MARIADB_USER}
       MARIADB_PASSWORD: ${MARIADB_PASSWORD}
@@ -32,6 +33,8 @@ services:
       resources:
         limits:
           memory: 512M
+    environment:
+      TZ: "Asia/Seoul"
     command: redis-server --requirepass ${REDIS_PASSWORD} --maxmemory 512M  
     
   backend-api:
@@ -46,6 +49,8 @@ services:
     volumes:
       - ${HOME}/d102/backend/api/logs:/app/logs
       - ${HOME}/d102/files:/files
+    environment:
+      TZ: "Asia/Seoul"
     restart: unless-stopped  
     
   backend-file:
@@ -60,6 +65,8 @@ services:
     volumes:
       - ${HOME}/d102/backend/file/logs:/app/logs
       - ${HOME}/d102/files:/files
+    environment:
+      TZ: "Asia/Seoul"
     restart: unless-stopped  
 
 networks:


### PR DESCRIPTION
## 이슈
- #31

## 어떤 이유로 MR를 하셨나요?
- feature 병합

## 작업 사항
- 백엔드 측 컨테이너 서버 시간 서울로 설정