### PR TITLE
[BE] fix: 개발 환경에서는 DB에 저장된 파일 경로 대신 로컬 경로 사용

### DIFF
--- a/api-ai/service/analysis.py
+++ b/api-ai/service/analysis.py
@@ -17,7 +17,15 @@ from sqlmodel import select
 
 @elapsed
 def _facial_emotional_recognition(record: Analysis) -> list:
-    video_path = os.path.join(settings.DATA_HOME, record.video_path)
+    # value of record.video_path seems like
+    # `/app/files/video/admin@d102.com/2024-03-29T15-28-00/test1.mp4`
+    # so, for the dev environment, replace `/app/files` into `settings.DATA_HOME`
+    video_path = record.video_path
+    if settings.DEBUG:
+        video_path = os.path.join(
+            str(settings.DATA_HOME), video_path.replace("/app/files/", "")
+        )
+    logger.debug(f"{str(settings.DATA_HOME)=} {video_path = }")
 
     # check file exists
     if not os.path.exists(video_path):


### PR DESCRIPTION
## 이슈
- #183

## 어떤 이유로 MR를 하셨나요?
- 코드 개선

## 작업 사항
- DB에는 영상 파일 경로가 절대 경로로 저장되어 있음.
  - 예시: `/app/files/video/admin@d102.com/2024-03-29T15-28-00/test1.mp4`
- 하지만 로컬 개발 환경에서는 해당 경로가 없을 수 있기 때문에 `.env` 파일의 `DATA_HOME` 경로로 변환하여 사용.
  - 예시: `DATA_HOME`이 `/home/ubuntu/data`인 경우 `/home/ubuntu/data/video/admin@d102.com/2024-03-29T15-28-00/test1.mp4`와 같이 변경하여 사용.
  - 따라서 `/app/files` 이하 경로는 로컬에도 동일하게 맞춰주어야 함.

## 참고 사항

- 공유할 내용, 스크린샷 등을 넣어 주세요.