### PR TITLE
[BE] fix: 감정 클래스 개수 조정

### DIFF
--- a/api-ai/ai/resnet_proc.py
+++ b/api-ai/ai/resnet_proc.py
@@ -10,15 +10,7 @@ from ai.resnet9 import ImageClassificationBase, ResNet9
 from loguru import logger
 from torchvision.models import resnet18
 
-EMOTIONS = {
-    0: "Angry",
-    1: "Disgust",
-    2: "Fear",
-    3: "Happy",
-    4: "Sad",
-    5: "Surprise",
-    6: "Neutral",
-}
+EMOTIONS = {0: "Negative", 1: "Neutral", 2: "Positive"}
 
 __haar_cascade = cv2.CascadeClassifier(
     cv2.data.haarcascades + "haarcascade_frontalface_default.xml"


### PR DESCRIPTION
## 이슈
- #168

## 어떤 이유로 MR를 하셨나요?
- 코드 개선

## 작업 사항
- 표정 분류를 위한 모델 학습에 [한국인 감정인식을 위한 복합 영상](https://aihub.or.kr/aihubdata/data/view.do?currMenu=115&topMenu=100&aihubDataSe=realm&dataSetSn=82) 데이터셋을 사용
- 기존에는 표정을 위 데이터셋에 포함된 7개 클래스(`기쁨`, `놀람`, `분노` 등)로 나누었으나, 면접 시에 `분노`와 같은 감정을 보이는 경우는 많지 않을 것이라 판단.
- 따라서 감정 클래스를 `긍정`, `중립`, `부정` 3개로 축소.

## 참고 사항

- 공유할 내용, 스크린샷 등을 넣어 주세요.